### PR TITLE
Add Route53 PHZ cross‑VPC example

### DIFF
--- a/route53_private_hosted_zone_ec2_resolve/deploy.sh
+++ b/route53_private_hosted_zone_ec2_resolve/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+terraform init
+terraform apply -auto-approve

--- a/route53_private_hosted_zone_ec2_resolve/destroy.sh
+++ b/route53_private_hosted_zone_ec2_resolve/destroy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+terraform destroy -auto-approve

--- a/route53_private_hosted_zone_ec2_resolve/main.tf
+++ b/route53_private_hosted_zone_ec2_resolve/main.tf
@@ -1,0 +1,226 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-3"
+}
+
+# -----------------------
+# VPC A and related resources
+# -----------------------
+resource "aws_vpc" "vpc_a" {
+  cidr_block           = "10.10.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = { Name = "vpc-a" }
+}
+
+resource "aws_subnet" "subnet_a" {
+  vpc_id                  = aws_vpc.vpc_a.id
+  cidr_block              = "10.10.1.0/24"
+  availability_zone       = "ap-southeast-3a"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "subnet-a" }
+}
+
+resource "aws_internet_gateway" "igw_a" {
+  vpc_id = aws_vpc.vpc_a.id
+  tags   = { Name = "igw-a" }
+}
+
+resource "aws_route_table" "rt_a" {
+  vpc_id = aws_vpc.vpc_a.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw_a.id
+  }
+
+  tags = { Name = "rt-a" }
+}
+
+resource "aws_route_table_association" "rta_a" {
+  subnet_id      = aws_subnet.subnet_a.id
+  route_table_id = aws_route_table.rt_a.id
+}
+
+# -----------------------
+# VPC B and related resources
+# -----------------------
+resource "aws_vpc" "vpc_b" {
+  cidr_block           = "10.20.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = { Name = "vpc-b" }
+}
+
+resource "aws_subnet" "subnet_b" {
+  vpc_id                  = aws_vpc.vpc_b.id
+  cidr_block              = "10.20.1.0/24"
+  availability_zone       = "ap-southeast-3a"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "subnet-b" }
+}
+
+resource "aws_internet_gateway" "igw_b" {
+  vpc_id = aws_vpc.vpc_b.id
+  tags   = { Name = "igw-b" }
+}
+
+resource "aws_route_table" "rt_b" {
+  vpc_id = aws_vpc.vpc_b.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw_b.id
+  }
+
+  tags = { Name = "rt-b" }
+}
+
+resource "aws_route_table_association" "rta_b" {
+  subnet_id      = aws_subnet.subnet_b.id
+  route_table_id = aws_route_table.rt_b.id
+}
+
+# -----------------------
+# VPC peering and routes
+# -----------------------
+resource "aws_vpc_peering_connection" "peer" {
+  vpc_id      = aws_vpc.vpc_a.id
+  peer_vpc_id = aws_vpc.vpc_b.id
+  auto_accept = true
+  tags        = { Name = "vpc-a-b-peer" }
+}
+
+resource "aws_route" "a_to_b" {
+  route_table_id            = aws_route_table.rt_a.id
+  destination_cidr_block    = aws_vpc.vpc_b.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+}
+
+resource "aws_route" "b_to_a" {
+  route_table_id            = aws_route_table.rt_b.id
+  destination_cidr_block    = aws_vpc.vpc_a.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+}
+
+# -----------------------
+# Security groups
+# -----------------------
+resource "aws_security_group" "sg_a" {
+  name   = "sg-a"
+  vpc_id = aws_vpc.vpc_a.id
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = [aws_vpc.vpc_b.cidr_block]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = { Name = "sg-a" }
+}
+
+resource "aws_security_group" "sg_b" {
+  name   = "sg-b"
+  vpc_id = aws_vpc.vpc_b.id
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = [aws_vpc.vpc_a.cidr_block]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = { Name = "sg-b" }
+}
+
+# -----------------------
+# EC2 instances
+# -----------------------
+data "aws_ami" "al2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "instance_a" {
+  ami                         = data.aws_ami.al2.id
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.subnet_a.id
+  vpc_security_group_ids      = [aws_security_group.sg_a.id]
+  associate_public_ip_address = true
+  tags                        = { Name = "instance-a" }
+}
+
+resource "aws_instance" "instance_b" {
+  ami                         = data.aws_ami.al2.id
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.subnet_b.id
+  vpc_security_group_ids      = [aws_security_group.sg_b.id]
+  associate_public_ip_address = true
+  tags                        = { Name = "instance-b" }
+}
+
+# -----------------------
+# Private hosted zone and records
+# -----------------------
+resource "aws_route53_zone" "phz" {
+  name = "demo.internal"
+  vpc { vpc_id = aws_vpc.vpc_a.id }
+  vpc { vpc_id = aws_vpc.vpc_b.id }
+  comment = "Shared private zone"
+}
+
+resource "aws_route53_record" "a_record" {
+  zone_id = aws_route53_zone.phz.zone_id
+  name    = "a.demo.internal"
+  type    = "A"
+  ttl     = 60
+  records = [aws_instance.instance_a.private_ip]
+}
+
+resource "aws_route53_record" "b_record" {
+  zone_id = aws_route53_zone.phz.zone_id
+  name    = "b.demo.internal"
+  type    = "A"
+  ttl     = 60
+  records = [aws_instance.instance_b.private_ip]
+}

--- a/route53_private_hosted_zone_ec2_resolve/readme.md
+++ b/route53_private_hosted_zone_ec2_resolve/readme.md
@@ -1,0 +1,48 @@
+# 🏷️ Route53 Private Hosted Zone with EC2 Resolution
+
+This example shows how two VPCs in the **ap-southeast-3 (Jakarta)** region can share a Route53 Private Hosted Zone so that EC2 instances resolve each other by hostname. A VPC peering connection provides network reachability.
+
+## 🌐 Architecture
+- **VPC A** `10.10.0.0/16` with a public subnet and EC2 **instance-a**
+- **VPC B** `10.20.0.0/16` with a public subnet and EC2 **instance-b**
+- **Peering** connection `vpc-a-b-peer` linking the VPCs
+- **Route53 PHZ** `demo.internal` associated with both VPCs
+- **A Records** `a.demo.internal` & `b.demo.internal` -> private IPs of the instances
+
+The diagram is essentially:
+
+```
+instance-a (VPC A) <--> Peering <--> instance-b (VPC B)
+             \__ shared Route53 Private Hosted Zone __/
+```
+
+## 🚀 Deployment
+1. Initialize and apply the Terraform configuration:
+   ```bash
+   ./deploy.sh
+   ```
+   This provisions the VPCs, instances, peering connection, and Route53 zone.
+2. Wait a few minutes for the EC2 instances to boot and register their DNS records.
+
+## 🔎 Verification
+After deployment connect to either EC2 instance (via SSH or Session Manager) and run the helper script included here:
+
+```bash
+cat test_dns_ping.sh
+```
+Copy its contents to a file on the instance and execute:
+
+```bash
+bash test_dns_ping.sh b.demo.internal   # from instance-a
+bash test_dns_ping.sh a.demo.internal   # from instance-b
+```
+
+You should see successful ping replies, confirming the instances resolve each other using the private hosted zone. 🎉
+
+## 🧹 Cleanup
+When done, destroy all resources:
+```bash
+./destroy.sh
+```
+
+Enjoy exploring Route53 Private Hosted Zones! 😎

--- a/route53_private_hosted_zone_ec2_resolve/test_dns_ping.sh
+++ b/route53_private_hosted_zone_ec2_resolve/test_dns_ping.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Simple utility to verify DNS resolution and connectivity
+# Usage: bash test_dns_ping.sh <fqdn-to-ping>
+set -euo pipefail
+
+TARGET=${1:-}
+if [[ -z "$TARGET" ]]; then
+  echo "Usage: $0 <fqdn-to-ping>" >&2
+  exit 1
+fi
+
+echo "Resolving $TARGET ..."
+dig +short "$TARGET" || true
+
+echo "Pinging $TARGET ..."
+ping -c 4 "$TARGET"
+


### PR DESCRIPTION
## Summary
- add `route53_private_hosted_zone_ec2_resolve` example
- allow two VPCs to share a private hosted zone
- expand README details with emojis and add EC2 test script

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b17e55c832bbd8ce258defad63d